### PR TITLE
feat: disconnected mode

### DIFF
--- a/src/elev/elev.go
+++ b/src/elev/elev.go
@@ -164,6 +164,13 @@ func ReassignOrders(
 	bidTxSecure chan types.Msg[types.Bid],
 ) {
 
+	isAlone := elevState.NextNodeID == elevConfig.NodeID
+	disconnected := elevState.NextNodeID == -1
+
+	if isAlone || disconnected {
+		return
+	}
+
 	for floor := range elevState.Orders[nodeID] {
 		for orderType, orderStatus := range elevState.Orders[nodeID][floor] {
 			if !orderStatus || orderType == elevio.BT_Cab {

--- a/src/elev/elev.go
+++ b/src/elev/elev.go
@@ -5,7 +5,6 @@ import (
 	"elevator/fsm"
 	"elevator/network"
 	"elevator/types"
-	"fmt"
 	"slices"
 	"strconv"
 )
@@ -59,8 +58,9 @@ func SetState(
 		}
 
 		isAlone := newState.NextNodeID == elevConfig.NodeID
+		disconnected := newState.NextNodeID == -1
 
-		if isAlone {
+		if isAlone || disconnected {
 			newState = *SetOrderStatus(
 				&newState,
 				elevConfig,
@@ -175,7 +175,6 @@ func ReassignOrders(
 				Floor:  floor,
 			}
 
-			fmt.Println("Reassigning order: ", order, " from ", nodeID)
 			bidTxSecure <- network.FormatBidMsg(
 				nil,
 				order,
@@ -250,6 +249,11 @@ func SetNextNodeID(
 	slices.Sort(peers)
 
 	indexOfNodeID := indexOf(peers, elevConfig.NodeID)
+
+	if len(peers) == 0 {
+		elevState.NextNodeID = -1
+		return elevState
+	}
 
 	if 0 > indexOfNodeID {
 		return elevState

--- a/src/elev/handlers.go
+++ b/src/elev/handlers.go
@@ -21,8 +21,9 @@ func HandleNewOrder(
 
 	isCabOrder := order.Button == elevio.BT_Cab
 	isAlone := elevState.NextNodeID == elevConfig.NodeID
+	disconnected := elevState.NextNodeID == -1
 
-	if isAlone && isCabOrder {
+	if (isAlone || disconnected) && isCabOrder {
 		elevState = SelfAssignOrder(
 			elevState,
 			elevConfig,
@@ -32,7 +33,7 @@ func HandleNewOrder(
 			doorTimer,
 			floorTimer,
 		)
-	} else if !isAlone && isCabOrder {
+	} else if !isAlone && !disconnected && isCabOrder {
 		assignTxSecure <- network.FormatAssignMsg(
 			order,
 			elevConfig.NodeID,
@@ -40,7 +41,7 @@ func HandleNewOrder(
 			elevState.NextNodeID,
 			elevConfig.NodeID,
 		)
-	} else {
+	} else if !disconnected {
 		bidTxSecure <- network.FormatBidMsg(
 			nil,
 			order,


### PR DESCRIPTION
# Changes
- When the node is disconnected the list of peers will be empty. When this happens we can set the next node id to -1, indicating disconnection.